### PR TITLE
Percentages for game amounts on pie charts are now displayed correctly

### DIFF
--- a/frontend/src/components/player-relations/index.js
+++ b/frontend/src/components/player-relations/index.js
@@ -49,7 +49,7 @@ class PlayerRelations extends React.Component {
   ])
 
   setPieChartData = (relations) => relations.map((relation, index) =>
-    ({value: relation.countGames, label: `${relation.partner.fullName} (${this.props.gamesPlayed / relation.countGames * 100}%)`, ...ChartColors[index]}))
+    ({value: relation.countGames, label: `${relation.partner.fullName} (${100 * relation.countGames / this.props.gamesPlayed}%)`, ...ChartColors[index]}))
 
   getOptions = () => this.props.relations.map(i => ({value: i.partner.id, label: i.partner.fullName}))
 


### PR DESCRIPTION
This PR fixes the issue when meaningless values were being shown for game amounts in pie chart tooltips:
![image](https://user-images.githubusercontent.com/4269717/54756981-59ae1980-4bfa-11e9-9e83-e4f06d3c9487.png)
